### PR TITLE
Clean pkgmap builds for stdlib using go install'd toolchain

### DIFF
--- a/cmd/gen-import-interop/main.go
+++ b/cmd/gen-import-interop/main.go
@@ -4,349 +4,386 @@ import (
 	"flag"
 	"fmt"
 	"go/constant"
+	"go/format"
 	"go/importer"
 	"go/token"
 	"go/types"
+	"math"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
 )
 
-var (
-	// we're including the entire stdlib here for now.
-	defaultPackages = []string{
-		"archive/tar",
-		"archive/zip",
-		"bufio",
-		"bytes",
-		"compress/bzip2",
-		"compress/flate",
-		"compress/gzip",
-		"compress/lzw",
-		"compress/zlib",
-		"container/heap",
-		"container/list",
-		"container/ring",
-		"context",
-		"crypto",
-		"crypto/aes",
-		"crypto/cipher",
-		"crypto/des",
-		"crypto/dsa",
-		"crypto/ecdsa",
-		"crypto/ed25519",
-		"crypto/elliptic",
-		"crypto/hmac",
-		"crypto/md5",
-		"crypto/rand",
-		"crypto/rc4",
-		"crypto/rsa",
-		"crypto/sha1",
-		"crypto/sha256",
-		"crypto/sha512",
-		"crypto/subtle",
-		"crypto/tls",
-		"crypto/x509",
-		"crypto/x509/pkix",
-		"database/sql",
-		"database/sql/driver",
-		"debug/buildinfo",
-		"debug/dwarf",
-		"debug/elf",
-		"debug/gosym",
-		"debug/macho",
-		"debug/pe",
-		"debug/plan9obj",
-		"embed",
-		"encoding",
-		"encoding/ascii85",
-		"encoding/asn1",
-		"encoding/base32",
-		"encoding/base64",
-		"encoding/binary",
-		"encoding/csv",
-		"encoding/gob",
-		"encoding/hex",
-		"encoding/json",
-		"encoding/pem",
-		"encoding/xml",
-		"errors",
-		"expvar",
-		"flag",
-		"fmt",
-		"go/ast",
-		"go/build",
-		"go/build/constraint",
-		"go/constant",
-		"go/doc",
-		"go/doc/comment",
-		"go/format",
-		"go/importer",
-		"go/parser",
-		"go/printer",
-		"go/scanner",
-		"go/token",
-		"go/types",
-		"hash",
-		"hash/adler32",
-		"hash/crc32",
-		"hash/crc64",
-		"hash/fnv",
-		"hash/maphash",
-		"html",
-		"html/template",
-		"image",
-		"image/color",
-		"image/color/palette",
-		"image/draw",
-		"image/gif",
-		"image/jpeg",
-		"image/png",
-		"index/suffixarray",
-		"io",
-		"io/fs",
-		"io/ioutil",
-		"log",
-		"math",
-		"math/big",
-		"math/bits",
-		"math/cmplx",
-		"math/rand",
-		"mime",
-		"mime/multipart",
-		"mime/quotedprintable",
-		"net",
-		"net/http",
-		"net/http/cgi",
-		"net/http/cookiejar",
-		"net/http/fcgi",
-		"net/http/httptest",
-		"net/http/httptrace",
-		"net/http/pprof",
-		"net/mail",
-		"net/netip",
-		"net/rpc",
-		"net/rpc/jsonrpc",
-		"net/smtp",
-		"net/textproto",
-		"net/url",
-		"os",
-		"os/exec",
-		"os/signal",
-		"os/user",
-		"path",
-		"path/filepath",
-		"plugin",
-		"reflect",
-		"regexp",
-		"regexp/syntax",
-		"runtime",
-		// "runtime/cgo", // exclude cgo because it imposes a dependency on cgo
-		"runtime/debug",
-		"runtime/metrics",
-		"runtime/pprof",
-		"runtime/race",
-		"runtime/trace",
-		"sort",
-		"strconv",
-		"strings",
-		"sync",
-		"sync/atomic",
-		"syscall",
-		"testing",
-		"testing/fstest",
-		"testing/iotest",
-		"testing/quick",
-		"text/scanner",
-		"text/tabwriter",
-		"text/template",
-		"text/template/parse",
-		"time",
-		"time/tzdata",
-		"unicode",
-		"unicode/utf16",
-		"unicode/utf8",
-		"unsafe",
+var defaultPackages = []string{
+	"archive/tar",
+	"archive/zip",
+	"bufio",
+	"bytes",
+	"compress/bzip2",
+	"compress/flate",
+	"compress/gzip",
+	"compress/lzw",
+	"compress/zlib",
+	"container/heap",
+	"container/list",
+	"container/ring",
+	"context",
+	"crypto",
+	"crypto/aes",
+	"crypto/cipher",
+	"crypto/des",
+	"crypto/dsa",
+	"crypto/ecdsa",
+	"crypto/ed25519",
+	"crypto/elliptic",
+	"crypto/hmac",
+	"crypto/md5",
+	"crypto/rand",
+	"crypto/rc4",
+	"crypto/rsa",
+	"crypto/sha1",
+	"crypto/sha256",
+	"crypto/sha512",
+	"crypto/subtle",
+	"crypto/tls",
+	"crypto/x509",
+	"crypto/x509/pkix",
+	"database/sql",
+	"database/sql/driver",
+	"debug/buildinfo",
+	"debug/dwarf",
+	"debug/elf",
+	"debug/gosym",
+	"debug/macho",
+	"debug/pe",
+	"debug/plan9obj",
+	"embed",
+	"encoding",
+	"encoding/ascii85",
+	"encoding/asn1",
+	"encoding/base32",
+	"encoding/base64",
+	"encoding/binary",
+	"encoding/csv",
+	"encoding/gob",
+	"encoding/hex",
+	"encoding/json",
+	"encoding/pem",
+	"encoding/xml",
+	"errors",
+	"expvar",
+	"flag",
+	"fmt",
+	"go/ast",
+	"go/build",
+	"go/build/constraint",
+	"go/constant",
+	"go/doc",
+	"go/doc/comment",
+	"go/format",
+	"go/importer",
+	"go/parser",
+	"go/printer",
+	"go/scanner",
+	"go/token",
+	"go/types",
+	"hash",
+	"hash/adler32",
+	"hash/crc32",
+	"hash/crc64",
+	"hash/fnv",
+	"hash/maphash",
+	"html",
+	"html/template",
+	"image",
+	"image/color",
+	"image/color/palette",
+	"image/draw",
+	"image/gif",
+	"image/jpeg",
+	"image/png",
+	"index/suffixarray",
+	"io",
+	"io/fs",
+	"io/ioutil",
+	"log",
+	"math",
+	"math/big",
+	"math/bits",
+	"math/cmplx",
+	"math/rand",
+	"mime",
+	"mime/multipart",
+	"mime/quotedprintable",
+	"net",
+	"net/http",
+	"net/http/cgi",
+	"net/http/cookiejar",
+	"net/http/fcgi",
+	"net/http/httptest",
+	"net/http/httptrace",
+	"net/http/pprof",
+	"net/mail",
+	"net/netip",
+	"net/rpc",
+	"net/rpc/jsonrpc",
+	"net/smtp",
+	"net/textproto",
+	"net/url",
+	"os",
+	"os/exec",
+	"os/signal",
+	"os/user",
+	"path",
+	"path/filepath",
+	"plugin",
+	"reflect",
+	"regexp",
+	"regexp/syntax",
+	"runtime",
+	// "runtime/cgo", // exclude cgo because it imposes a dependency on cgo
+	"runtime/debug",
+	"runtime/metrics",
+	"runtime/pprof",
+	"runtime/race",
+	"runtime/trace",
+	"sort",
+	"strconv",
+	"strings",
+	"sync",
+	"sync/atomic",
+	"syscall",
+	"testing",
+	"testing/fstest",
+	"testing/iotest",
+	"testing/quick",
+	"text/scanner",
+	"text/tabwriter",
+	"text/template",
+	"text/template/parse",
+	"time",
+	"time/tzdata",
+	"unicode",
+	"unicode/utf16",
+	"unicode/utf8",
+	"unsafe",
 
-		"github.com/glojurelang/glojure/pkg/runtime",
-		"github.com/glojurelang/glojure/pkg/lang",
-	}
+	"github.com/glojurelang/glojure/pkg/runtime",
+	"github.com/glojurelang/glojure/pkg/lang",
+}
+
+var packagesFlag = flag.String(
+	"packages",
+	"",
+	"comma separated list of packages to import",
 )
 
-var (
-	packages = flag.String("packages", "", "comma separated list of packages to import")
-)
-
-type (
-	export struct {
-		name string
-		obj  types.Object
-	}
-)
+type export struct {
+	name string
+	obj  types.Object
+}
 
 func main() {
 	flag.Parse()
 
-	pkgs := defaultPackages
-	if *packages != "" {
-		pkgs = strings.Split(*packages, ",")
+	packages := defaultPackages
+	if *packagesFlag != "" {
+		packages = strings.Split(*packagesFlag, ",")
 	}
 
-	pkgExports := make(map[string][]export)
-	pkgNames := make([]string, 0, len(pkgs))
+	sortedPackageNames, packageExports := collectExportedObjects(packages)
+	printGeneratedCode(sortedPackageNames, packageExports)
+}
 
-	builder := &strings.Builder{}
-	builder.WriteString("// GENERATED FILE. DO NOT EDIT.\n")
-	builder.WriteString("package gljimports\n\n")
-	builder.WriteString("import (\n")
-	importedReflect := false
-	for _, pkgName := range pkgs {
-		pkg, err := importer.ForCompiler(token.NewFileSet(), "source", nil).Import(pkgName)
+func collectExportedObjects(packages []string) ([]string, map[string][]export) {
+	var packageNames []string
+	packageExports := map[string][]export{}
+
+	fileSet := token.NewFileSet()
+	sourceImporter := importer.ForCompiler(fileSet, "source", nil)
+
+	for _, packageName := range packages {
+		packageData, err := sourceImporter.Import(packageName)
 		if err != nil {
 			panic(err)
 		}
-		exports := make([]export, 0, len(pkgNames))
-		for _, declName := range pkg.Scope().Names() {
-			obj := pkg.Scope().Lookup(declName)
-			if !obj.Exported() {
-				continue
-			}
 
-			if pkgName+"."+declName == "runtime.GOTOOLDIR" {
-				// TODO: use a non-nix go installation to generate the
-				// standard library mappings. nix patches extern.go to add the
-				// GOTOOLDIR function.
-				continue
+		var exportedObjects []export
+		for _, exportedObjectName := range packageData.Scope().Names() {
+			object := packageData.Scope().Lookup(exportedObjectName)
+			if isEligibleForExport(object, packageName) {
+				exportedObjects = append(exportedObjects, export{
+					name: exportedObjectName,
+					obj:  object,
+				})
 			}
-			if _, ok := obj.(*types.Builtin); ok {
-				// Builtin types can't be used as values, and so we can't map
-				// them.
-				continue
-			}
-			exports = append(exports, export{
-				name: declName,
-				obj:  obj,
-			})
-		}
-		if len(exports) == 0 {
-			continue
-		}
-		pkgExports[pkgName] = exports
-		pkgNames = append(pkgNames, pkgName)
-
-		if pkgName == "reflect" {
-			importedReflect = true
 		}
 
-		aliasName := strings.NewReplacer(".", "_", "/", "_", "-", "_").Replace(pkgName)
-		builder.WriteString(fmt.Sprintf("\t%s \"%s\"\n", aliasName, pkgName))
+		if len(exportedObjects) > 0 {
+			packageExports[packageName] = exportedObjects
+			packageNames = append(packageNames, packageName)
+		}
 	}
-	sort.Strings(pkgNames)
 
-	// import reflect if not already imported. it's needed for
-	// type.TypeOf.
-	if !importedReflect {
-		builder.WriteString("\t\"reflect\"\n")
+	sort.Strings(packageNames)
+
+	return packageNames, packageExports
+}
+
+func isEligibleForExport(object types.Object, packageName string) bool {
+	if !object.Exported() {
+		return false
 	}
+
+	if _, isIllegalType := object.(*types.Builtin); isIllegalType {
+		return false
+	}
+
+	return true
+}
+
+func printGeneratedCode(packageNames []string, packageExports map[string][]export) {
+	builder := createHeaderBuilder(packageNames)
+	createFunctionBuilder(builder, packageNames, packageExports)
+
+	formattedCode, err := format.Source([]byte(builder.String()))
+	if err != nil {
+		panic(err)
+	}
+
+	os.Stdout.Write(formattedCode)
+	os.Stdout.Sync()
+}
+
+func createHeaderBuilder(packageNames []string) *strings.Builder {
+	builder := &strings.Builder{}
+
+	builder.WriteString("// GENERATED FILE. DO NOT EDIT.\n")
+	builder.WriteString("package gljimports\n\n")
+	builder.WriteString("import (\n")
+
+	for _, packageName := range packageNames {
+		aliasName := strings.NewReplacer(".", "_", "/", "_", "-", "_").Replace(packageName)
+		builder.WriteString(fmt.Sprintf("\t%s \"%s\"\n", aliasName, packageName))
+	}
+
 	builder.WriteString(")\n\n")
 
+	return builder
+}
+
+func createFunctionBuilder(builder *strings.Builder, packageNames []string, packageExports map[string][]export) {
 	builder.WriteString("func RegisterImports(_register func(string, interface{})) {\n")
-	for i, pkgName := range pkgNames {
-		if i > 0 {
-			builder.WriteRune('\n')
+
+	first := true
+	for _, packageName := range packageNames {
+		if !first {
+			builder.WriteString("\n")
 		}
-		builder.WriteString(fmt.Sprintf("\t// package %s\n", pkgName))
-		builder.WriteString(fmt.Sprintf("\t%s\n", strings.Repeat("//", 20)))
-
-		for _, export := range pkgExports[pkgName] {
-			declName := export.name
-			obj := export.obj
-
-			glojureDeclName := fmt.Sprintf("%s.%s", pkgName, declName)
-
-			pkgImportName := strings.NewReplacer(".", "_", "/", "_", "-", "_").Replace(pkgName)
-			qualifiedName := fmt.Sprintf("%s.%s", pkgImportName, declName)
-
-			var decl string
-
-			switch obj := obj.(type) {
-			case *types.Const:
-				val := obj.Val()
-				switch val.Kind() {
-				case constant.Bool, constant.String, constant.Complex:
-					decl = fmt.Sprintf("_register(%q, %s)", glojureDeclName, qualifiedName)
-				case constant.Int:
-					// TODO: derive type from constant. use the smallest type
-					// possible that can hold the value.
-
-					switch qualifiedName {
-					case "math.MaxUint":
-						decl = fmt.Sprintf("_register(%q, uint(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxUint64":
-						decl = fmt.Sprintf("_register(%q, uint64(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxUint32":
-						decl = fmt.Sprintf("_register(%q, uint32(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxUint16":
-						decl = fmt.Sprintf("_register(%q, uint16(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxUint8":
-						decl = fmt.Sprintf("_register(%q, uint8(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxInt":
-						decl = fmt.Sprintf("_register(%q, int(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxInt64":
-						decl = fmt.Sprintf("_register(%q, int64(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxInt32":
-						decl = fmt.Sprintf("_register(%q, int32(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxInt16":
-						decl = fmt.Sprintf("_register(%q, int16(%s))", glojureDeclName, qualifiedName)
-					case "math.MaxInt8":
-						decl = fmt.Sprintf("_register(%q, int8(%s))", glojureDeclName, qualifiedName)
-					case "math.MinInt":
-						decl = fmt.Sprintf("_register(%q, int(%s))", glojureDeclName, qualifiedName)
-					case "math.MinInt64":
-						decl = fmt.Sprintf("_register(%q, int64(%s))", glojureDeclName, qualifiedName)
-					case "math.MinInt32":
-						decl = fmt.Sprintf("_register(%q, int32(%s))", glojureDeclName, qualifiedName)
-					case "math.MinInt16":
-						decl = fmt.Sprintf("_register(%q, int16(%s))", glojureDeclName, qualifiedName)
-					case "math.MinInt8":
-						decl = fmt.Sprintf("_register(%q, int8(%s))", glojureDeclName, qualifiedName)
-					case "hash_crc64.ISO":
-						decl = fmt.Sprintf("_register(%q, uint64(%s))", glojureDeclName, qualifiedName)
-					case "hash_crc64.ECMA":
-						decl = fmt.Sprintf("_register(%q, uint64(%s))", glojureDeclName, qualifiedName)
-					default:
-						decl = fmt.Sprintf("_register(%q, %s)", glojureDeclName, qualifiedName)
-					}
-				case constant.Float:
-					decl = fmt.Sprintf("_register(%q, float64(%s))", glojureDeclName, qualifiedName)
-				default:
-					panic(fmt.Errorf("unknown constant type: %s", val.Kind()))
-				}
-			case *types.Func:
-				decl = fmt.Sprintf("_register(%q, %s)", glojureDeclName, qualifiedName)
-			case *types.Var:
-				// if obj is a sync.Mutex or sync.RWMutex, map to its address
-				if obj.Type().String() == "sync.Mutex" || obj.Type().String() == "sync.RWMutex" {
-					decl = fmt.Sprintf("_register(%q, &%s)", glojureDeclName, qualifiedName)
-				} else {
-					decl = fmt.Sprintf("_register(%q, %s)", glojureDeclName, qualifiedName)
-				}
-			case *types.TypeName:
-				// skip generic types
-				if strings.HasSuffix(obj.Type().String(), "]") {
-					continue
-				}
-
-				decl = fmt.Sprintf("_register(%q, reflect.TypeOf((*%s)(nil)).Elem())", glojureDeclName, qualifiedName)
-			default:
-				panic(fmt.Sprintf("unknown type %T (%v)", obj, obj))
-			}
-			for _, line := range strings.Split(decl, "\n") {
-				builder.WriteRune('\t')
-				builder.WriteString(line)
-				builder.WriteRune('\n')
-			}
-		}
+		first = false
+		addPackageSection(builder, packageName, packageExports[packageName])
 	}
+
 	builder.WriteString("}\n")
-	fmt.Print(builder.String())
+}
+
+func addPackageSection(builder *strings.Builder, packageName string, packageExports []export) {
+	builder.WriteString(fmt.Sprintf("\t// package %s\n", packageName))
+	builder.WriteString("\t////////////////////////////////////////\n")
+
+	packageAlias := replaceSpecChars(packageName)
+
+	for _, exportedObject := range packageExports {
+		declareExportedObject(builder, exportedObject, packageName, packageAlias)
+	}
+}
+
+func replaceSpecChars(value string) string {
+	return strings.NewReplacer(".", "_", "/", "_", "-", "_").Replace(value)
+}
+
+func declareExportedObject(builder *strings.Builder, exportedObject export, packageName string, packageAlias string) {
+	globalName := fmt.Sprintf("%s.%s", packageName, exportedObject.name)
+	aliasName := fmt.Sprintf("%s.%s", packageAlias, exportedObject.name)
+
+	decl := getDeclaration(exportedObject.obj, globalName, aliasName)
+
+	for _, line := range strings.Split(decl, "\n") {
+		builder.WriteRune('\t')
+		builder.WriteString(line)
+		builder.WriteRune('\n')
+	}
+}
+
+func getDeclaration(object types.Object, globalName string, aliasName string) string {
+	switch concreteObject := object.(type) {
+	case *types.Const:
+		return getConstDeclaration(concreteObject, globalName, aliasName)
+	case *types.Func:
+		return fmt.Sprintf("_register(%q, %s)", globalName, aliasName)
+	case *types.Var:
+		return getVarDeclaration(concreteObject, globalName, aliasName)
+	case *types.TypeName:
+		return getTypeNameDeclaration(concreteObject, globalName, aliasName)
+	default:
+		panic(fmt.Errorf("unknown type %T (%v)", object, object))
+	}
+}
+
+func getConstDeclaration(object *types.Const, globalName string, aliasName string) string {
+	value := object.Val()
+
+	switch value.Kind() {
+	case constant.Bool, constant.String, constant.Complex:
+		return fmt.Sprintf("_register(%q, %s)", globalName, aliasName)
+	case constant.Int:
+		val := aliasName
+		if intType := getTypedInt(value.ExactString()); intType != "" {
+			val = fmt.Sprintf("%s(%s)", intType, val)
+		}
+		return fmt.Sprintf("_register(%q, %s)", globalName, val)
+	case constant.Float:
+		return fmt.Sprintf("_register(%q, float64(%s))", globalName, aliasName)
+	default:
+		panic(fmt.Errorf("unknown constant type: %s", value.Kind()))
+	}
+}
+
+func getVarDeclaration(object *types.Var, globalName string, aliasName string) string {
+	typeName := object.Type().String()
+
+	if typeName == "sync.Mutex" || typeName == "sync.RWMutex" {
+		return fmt.Sprintf("_register(%q, &%s)", globalName, aliasName)
+	}
+
+	return fmt.Sprintf("_register(%q, %s)", globalName, aliasName)
+}
+
+func getTypeNameDeclaration(object *types.TypeName, globalName string, aliasName string) string {
+	isGeneric := strings.HasSuffix(object.Type().String(), "]")
+
+	if isGeneric {
+		return ""
+	}
+
+	return fmt.Sprintf("_register(%q, reflect.TypeOf((*%s)(nil)).Elem())", globalName, aliasName)
+}
+
+// getTypedInt derives the type of the integer literal from its string
+// representation. Use the smallest type >= int that can represent the value.
+func getTypedInt(value string) string {
+	if v, err := strconv.ParseInt(value, 10, 0); err == nil && v >= math.MinInt && v <= math.MaxInt {
+		return ""
+	} else if v, err := strconv.ParseInt(value, 10, 32); err == nil && v >= -2147483648 && v <= 2147483647 {
+		return "int32"
+	} else if v, err := strconv.ParseUint(value, 10, 32); err == nil && v <= 4294967295 {
+		return "uint32"
+	} else if v, err := strconv.ParseInt(value, 10, 64); err == nil && v >= -9223372036854775808 && v <= 9223372036854775807 {
+		return "int64"
+	} else if _, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return "uint64"
+	} else {
+		panic(fmt.Errorf("cannot determine type of integer literal %s", value))
+	}
 }

--- a/pkg/gen/gljimports/gljimports_darwin_amd64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_amd64.go
@@ -63,6 +63,8 @@ import (
 	expvar "expvar"
 	flag "flag"
 	fmt "fmt"
+	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
+	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
 	go_ast "go/ast"
 	go_build "go/build"
 	go_build_constraint "go/build/constraint"
@@ -153,8 +155,6 @@ import (
 	unicode_utf16 "unicode/utf16"
 	unicode_utf8 "unicode/utf8"
 	unsafe "unsafe"
-	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
-	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
 )
 
 func RegisterImports(_register func(string, interface{})) {
@@ -4544,22 +4544,22 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("math.Max", math.Max)
 	_register("math.MaxFloat32", float64(math.MaxFloat32))
 	_register("math.MaxFloat64", float64(math.MaxFloat64))
-	_register("math.MaxInt", int(math.MaxInt))
-	_register("math.MaxInt16", int16(math.MaxInt16))
-	_register("math.MaxInt32", int32(math.MaxInt32))
-	_register("math.MaxInt64", int64(math.MaxInt64))
-	_register("math.MaxInt8", int8(math.MaxInt8))
-	_register("math.MaxUint", uint(math.MaxUint))
-	_register("math.MaxUint16", uint16(math.MaxUint16))
-	_register("math.MaxUint32", uint32(math.MaxUint32))
+	_register("math.MaxInt", math.MaxInt)
+	_register("math.MaxInt16", math.MaxInt16)
+	_register("math.MaxInt32", math.MaxInt32)
+	_register("math.MaxInt64", math.MaxInt64)
+	_register("math.MaxInt8", math.MaxInt8)
+	_register("math.MaxUint", uint64(math.MaxUint))
+	_register("math.MaxUint16", math.MaxUint16)
+	_register("math.MaxUint32", math.MaxUint32)
 	_register("math.MaxUint64", uint64(math.MaxUint64))
-	_register("math.MaxUint8", uint8(math.MaxUint8))
+	_register("math.MaxUint8", math.MaxUint8)
 	_register("math.Min", math.Min)
-	_register("math.MinInt", int(math.MinInt))
-	_register("math.MinInt16", int16(math.MinInt16))
-	_register("math.MinInt32", int32(math.MinInt32))
-	_register("math.MinInt64", int64(math.MinInt64))
-	_register("math.MinInt8", int8(math.MinInt8))
+	_register("math.MinInt", math.MinInt)
+	_register("math.MinInt16", math.MinInt16)
+	_register("math.MinInt32", math.MinInt32)
+	_register("math.MinInt64", math.MinInt64)
+	_register("math.MinInt8", math.MinInt8)
 	_register("math.Mod", math.Mod)
 	_register("math.Modf", math.Modf)
 	_register("math.NaN", math.NaN)
@@ -5837,6 +5837,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("sync/atomic.LoadUint32", sync_atomic.LoadUint32)
 	_register("sync/atomic.LoadUint64", sync_atomic.LoadUint64)
 	_register("sync/atomic.LoadUintptr", sync_atomic.LoadUintptr)
+
 	_register("sync/atomic.StoreInt32", sync_atomic.StoreInt32)
 	_register("sync/atomic.StoreInt64", sync_atomic.StoreInt64)
 	_register("sync/atomic.StorePointer", sync_atomic.StorePointer)

--- a/pkg/gen/gljimports/gljimports_darwin_arm64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_arm64.go
@@ -63,6 +63,8 @@ import (
 	expvar "expvar"
 	flag "flag"
 	fmt "fmt"
+	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
+	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
 	go_ast "go/ast"
 	go_build "go/build"
 	go_build_constraint "go/build/constraint"
@@ -153,8 +155,6 @@ import (
 	unicode_utf16 "unicode/utf16"
 	unicode_utf8 "unicode/utf8"
 	unsafe "unsafe"
-	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
-	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
 )
 
 func RegisterImports(_register func(string, interface{})) {
@@ -4544,22 +4544,22 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("math.Max", math.Max)
 	_register("math.MaxFloat32", float64(math.MaxFloat32))
 	_register("math.MaxFloat64", float64(math.MaxFloat64))
-	_register("math.MaxInt", int(math.MaxInt))
-	_register("math.MaxInt16", int16(math.MaxInt16))
-	_register("math.MaxInt32", int32(math.MaxInt32))
-	_register("math.MaxInt64", int64(math.MaxInt64))
-	_register("math.MaxInt8", int8(math.MaxInt8))
-	_register("math.MaxUint", uint(math.MaxUint))
-	_register("math.MaxUint16", uint16(math.MaxUint16))
-	_register("math.MaxUint32", uint32(math.MaxUint32))
+	_register("math.MaxInt", math.MaxInt)
+	_register("math.MaxInt16", math.MaxInt16)
+	_register("math.MaxInt32", math.MaxInt32)
+	_register("math.MaxInt64", math.MaxInt64)
+	_register("math.MaxInt8", math.MaxInt8)
+	_register("math.MaxUint", uint64(math.MaxUint))
+	_register("math.MaxUint16", math.MaxUint16)
+	_register("math.MaxUint32", math.MaxUint32)
 	_register("math.MaxUint64", uint64(math.MaxUint64))
-	_register("math.MaxUint8", uint8(math.MaxUint8))
+	_register("math.MaxUint8", math.MaxUint8)
 	_register("math.Min", math.Min)
-	_register("math.MinInt", int(math.MinInt))
-	_register("math.MinInt16", int16(math.MinInt16))
-	_register("math.MinInt32", int32(math.MinInt32))
-	_register("math.MinInt64", int64(math.MinInt64))
-	_register("math.MinInt8", int8(math.MinInt8))
+	_register("math.MinInt", math.MinInt)
+	_register("math.MinInt16", math.MinInt16)
+	_register("math.MinInt32", math.MinInt32)
+	_register("math.MinInt64", math.MinInt64)
+	_register("math.MinInt8", math.MinInt8)
 	_register("math.Mod", math.Mod)
 	_register("math.Modf", math.Modf)
 	_register("math.NaN", math.NaN)
@@ -5837,6 +5837,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("sync/atomic.LoadUint32", sync_atomic.LoadUint32)
 	_register("sync/atomic.LoadUint64", sync_atomic.LoadUint64)
 	_register("sync/atomic.LoadUintptr", sync_atomic.LoadUintptr)
+
 	_register("sync/atomic.StoreInt32", sync_atomic.StoreInt32)
 	_register("sync/atomic.StoreInt64", sync_atomic.StoreInt64)
 	_register("sync/atomic.StorePointer", sync_atomic.StorePointer)

--- a/pkg/gen/gljimports/gljimports_linux_amd64.go
+++ b/pkg/gen/gljimports/gljimports_linux_amd64.go
@@ -63,6 +63,8 @@ import (
 	expvar "expvar"
 	flag "flag"
 	fmt "fmt"
+	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
+	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
 	go_ast "go/ast"
 	go_build "go/build"
 	go_build_constraint "go/build/constraint"
@@ -153,8 +155,6 @@ import (
 	unicode_utf16 "unicode/utf16"
 	unicode_utf8 "unicode/utf8"
 	unsafe "unsafe"
-	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
-	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
 )
 
 func RegisterImports(_register func(string, interface{})) {
@@ -4544,22 +4544,22 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("math.Max", math.Max)
 	_register("math.MaxFloat32", float64(math.MaxFloat32))
 	_register("math.MaxFloat64", float64(math.MaxFloat64))
-	_register("math.MaxInt", int(math.MaxInt))
-	_register("math.MaxInt16", int16(math.MaxInt16))
-	_register("math.MaxInt32", int32(math.MaxInt32))
-	_register("math.MaxInt64", int64(math.MaxInt64))
-	_register("math.MaxInt8", int8(math.MaxInt8))
-	_register("math.MaxUint", uint(math.MaxUint))
-	_register("math.MaxUint16", uint16(math.MaxUint16))
-	_register("math.MaxUint32", uint32(math.MaxUint32))
+	_register("math.MaxInt", math.MaxInt)
+	_register("math.MaxInt16", math.MaxInt16)
+	_register("math.MaxInt32", math.MaxInt32)
+	_register("math.MaxInt64", math.MaxInt64)
+	_register("math.MaxInt8", math.MaxInt8)
+	_register("math.MaxUint", uint64(math.MaxUint))
+	_register("math.MaxUint16", math.MaxUint16)
+	_register("math.MaxUint32", math.MaxUint32)
 	_register("math.MaxUint64", uint64(math.MaxUint64))
-	_register("math.MaxUint8", uint8(math.MaxUint8))
+	_register("math.MaxUint8", math.MaxUint8)
 	_register("math.Min", math.Min)
-	_register("math.MinInt", int(math.MinInt))
-	_register("math.MinInt16", int16(math.MinInt16))
-	_register("math.MinInt32", int32(math.MinInt32))
-	_register("math.MinInt64", int64(math.MinInt64))
-	_register("math.MinInt8", int8(math.MinInt8))
+	_register("math.MinInt", math.MinInt)
+	_register("math.MinInt16", math.MinInt16)
+	_register("math.MinInt32", math.MinInt32)
+	_register("math.MinInt64", math.MinInt64)
+	_register("math.MinInt8", math.MinInt8)
 	_register("math.Mod", math.Mod)
 	_register("math.Modf", math.Modf)
 	_register("math.NaN", math.NaN)
@@ -5837,6 +5837,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("sync/atomic.LoadUint32", sync_atomic.LoadUint32)
 	_register("sync/atomic.LoadUint64", sync_atomic.LoadUint64)
 	_register("sync/atomic.LoadUintptr", sync_atomic.LoadUintptr)
+
 	_register("sync/atomic.StoreInt32", sync_atomic.StoreInt32)
 	_register("sync/atomic.StoreInt64", sync_atomic.StoreInt64)
 	_register("sync/atomic.StorePointer", sync_atomic.StorePointer)

--- a/pkg/gen/gljimports/gljimports_linux_arm64.go
+++ b/pkg/gen/gljimports/gljimports_linux_arm64.go
@@ -63,6 +63,8 @@ import (
 	expvar "expvar"
 	flag "flag"
 	fmt "fmt"
+	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
+	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
 	go_ast "go/ast"
 	go_build "go/build"
 	go_build_constraint "go/build/constraint"
@@ -153,8 +155,6 @@ import (
 	unicode_utf16 "unicode/utf16"
 	unicode_utf8 "unicode/utf8"
 	unsafe "unsafe"
-	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
-	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
 )
 
 func RegisterImports(_register func(string, interface{})) {
@@ -4544,22 +4544,22 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("math.Max", math.Max)
 	_register("math.MaxFloat32", float64(math.MaxFloat32))
 	_register("math.MaxFloat64", float64(math.MaxFloat64))
-	_register("math.MaxInt", int(math.MaxInt))
-	_register("math.MaxInt16", int16(math.MaxInt16))
-	_register("math.MaxInt32", int32(math.MaxInt32))
-	_register("math.MaxInt64", int64(math.MaxInt64))
-	_register("math.MaxInt8", int8(math.MaxInt8))
-	_register("math.MaxUint", uint(math.MaxUint))
-	_register("math.MaxUint16", uint16(math.MaxUint16))
-	_register("math.MaxUint32", uint32(math.MaxUint32))
+	_register("math.MaxInt", math.MaxInt)
+	_register("math.MaxInt16", math.MaxInt16)
+	_register("math.MaxInt32", math.MaxInt32)
+	_register("math.MaxInt64", math.MaxInt64)
+	_register("math.MaxInt8", math.MaxInt8)
+	_register("math.MaxUint", uint64(math.MaxUint))
+	_register("math.MaxUint16", math.MaxUint16)
+	_register("math.MaxUint32", math.MaxUint32)
 	_register("math.MaxUint64", uint64(math.MaxUint64))
-	_register("math.MaxUint8", uint8(math.MaxUint8))
+	_register("math.MaxUint8", math.MaxUint8)
 	_register("math.Min", math.Min)
-	_register("math.MinInt", int(math.MinInt))
-	_register("math.MinInt16", int16(math.MinInt16))
-	_register("math.MinInt32", int32(math.MinInt32))
-	_register("math.MinInt64", int64(math.MinInt64))
-	_register("math.MinInt8", int8(math.MinInt8))
+	_register("math.MinInt", math.MinInt)
+	_register("math.MinInt16", math.MinInt16)
+	_register("math.MinInt32", math.MinInt32)
+	_register("math.MinInt64", math.MinInt64)
+	_register("math.MinInt8", math.MinInt8)
 	_register("math.Mod", math.Mod)
 	_register("math.Modf", math.Modf)
 	_register("math.NaN", math.NaN)
@@ -5837,6 +5837,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("sync/atomic.LoadUint32", sync_atomic.LoadUint32)
 	_register("sync/atomic.LoadUint64", sync_atomic.LoadUint64)
 	_register("sync/atomic.LoadUintptr", sync_atomic.LoadUintptr)
+
 	_register("sync/atomic.StoreInt32", sync_atomic.StoreInt32)
 	_register("sync/atomic.StoreInt64", sync_atomic.StoreInt64)
 	_register("sync/atomic.StorePointer", sync_atomic.StorePointer)

--- a/pkg/gen/gljimports/gljimports_windows.go
+++ b/pkg/gen/gljimports/gljimports_windows.go
@@ -63,6 +63,8 @@ import (
 	expvar "expvar"
 	flag "flag"
 	fmt "fmt"
+	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
+	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
 	go_ast "go/ast"
 	go_build "go/build"
 	go_build_constraint "go/build/constraint"
@@ -153,8 +155,6 @@ import (
 	unicode_utf16 "unicode/utf16"
 	unicode_utf8 "unicode/utf8"
 	unsafe "unsafe"
-	github_com_glojurelang_glojure_pkg_runtime "github.com/glojurelang/glojure/pkg/runtime"
-	github_com_glojurelang_glojure_pkg_lang "github.com/glojurelang/glojure/pkg/lang"
 )
 
 func RegisterImports(_register func(string, interface{})) {
@@ -4544,22 +4544,22 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("math.Max", math.Max)
 	_register("math.MaxFloat32", float64(math.MaxFloat32))
 	_register("math.MaxFloat64", float64(math.MaxFloat64))
-	_register("math.MaxInt", int(math.MaxInt))
-	_register("math.MaxInt16", int16(math.MaxInt16))
-	_register("math.MaxInt32", int32(math.MaxInt32))
-	_register("math.MaxInt64", int64(math.MaxInt64))
-	_register("math.MaxInt8", int8(math.MaxInt8))
-	_register("math.MaxUint", uint(math.MaxUint))
-	_register("math.MaxUint16", uint16(math.MaxUint16))
-	_register("math.MaxUint32", uint32(math.MaxUint32))
+	_register("math.MaxInt", math.MaxInt)
+	_register("math.MaxInt16", math.MaxInt16)
+	_register("math.MaxInt32", math.MaxInt32)
+	_register("math.MaxInt64", math.MaxInt64)
+	_register("math.MaxInt8", math.MaxInt8)
+	_register("math.MaxUint", uint64(math.MaxUint))
+	_register("math.MaxUint16", math.MaxUint16)
+	_register("math.MaxUint32", math.MaxUint32)
 	_register("math.MaxUint64", uint64(math.MaxUint64))
-	_register("math.MaxUint8", uint8(math.MaxUint8))
+	_register("math.MaxUint8", math.MaxUint8)
 	_register("math.Min", math.Min)
-	_register("math.MinInt", int(math.MinInt))
-	_register("math.MinInt16", int16(math.MinInt16))
-	_register("math.MinInt32", int32(math.MinInt32))
-	_register("math.MinInt64", int64(math.MinInt64))
-	_register("math.MinInt8", int8(math.MinInt8))
+	_register("math.MinInt", math.MinInt)
+	_register("math.MinInt16", math.MinInt16)
+	_register("math.MinInt32", math.MinInt32)
+	_register("math.MinInt64", math.MinInt64)
+	_register("math.MinInt8", math.MinInt8)
 	_register("math.Mod", math.Mod)
 	_register("math.Modf", math.Modf)
 	_register("math.NaN", math.NaN)
@@ -5837,6 +5837,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("sync/atomic.LoadUint32", sync_atomic.LoadUint32)
 	_register("sync/atomic.LoadUint64", sync_atomic.LoadUint64)
 	_register("sync/atomic.LoadUintptr", sync_atomic.LoadUintptr)
+
 	_register("sync/atomic.StoreInt32", sync_atomic.StoreInt32)
 	_register("sync/atomic.StoreInt64", sync_atomic.StoreInt64)
 	_register("sync/atomic.StorePointer", sync_atomic.StorePointer)
@@ -6394,7 +6395,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("syscall.IPv6Mreq", reflect.TypeOf((*syscall.IPv6Mreq)(nil)).Elem())
 	_register("syscall.ImplementsGetwd", syscall.ImplementsGetwd)
 	_register("syscall.InterfaceInfo", reflect.TypeOf((*syscall.InterfaceInfo)(nil)).Elem())
-	_register("syscall.InvalidHandle", syscall.InvalidHandle)
+	_register("syscall.InvalidHandle", uint64(syscall.InvalidHandle))
 	_register("syscall.IpAdapterInfo", reflect.TypeOf((*syscall.IpAdapterInfo)(nil)).Elem())
 	_register("syscall.IpAddrString", reflect.TypeOf((*syscall.IpAddrString)(nil)).Elem())
 	_register("syscall.IpAddressString", reflect.TypeOf((*syscall.IpAddressString)(nil)).Elem())

--- a/scripts/gen-gljimports.sh
+++ b/scripts/gen-gljimports.sh
@@ -10,6 +10,7 @@ go build -o "${EXE}" ./cmd/gen-import-interop
 
 OUTPUT_FILE=$1
 PLATFORM=$2
+GO=$3
 
 IFS='_' read -ra OS_ARCH <<< "$PLATFORM"
 
@@ -23,7 +24,7 @@ else
 fi
 
 # disable CGO to avoid cross-compilation issues on darwin.
-IMPORTS=$(CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH "$EXE")
+IMPORTS=$(GOROOT=$($GO env GOROOT) CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH "$EXE")
 echo "//go:build $BUILD_TAG" > "$OUTPUT_FILE"
 echo >> "$OUTPUT_FILE"
 echo "$IMPORTS" >> "$OUTPUT_FILE"

--- a/test/glojure/test_glojure/core/async/basic.glj
+++ b/test/glojure/test_glojure/core/async/basic.glj
@@ -17,8 +17,6 @@
 (deftest simple-go
   (is (= 42 (a/<! (a/go 42)))))
 
-;; FIX offer and poll... they aren't as dumb as you thought
-
 (deftest offer!
   (is (true? (a/offer! (a/chan 1) 42)) "offer! should return true if accepted")
   (is (nil? (a/offer! (a/chan) 42)) "offer! should return nil if blocked"))


### PR DESCRIPTION
# Problem

For some reason, nix patches extern.go in the standard library's runtime package to add functions. This causes compilation failure when running with vanilla go.

# Solution

Build the standard library package map using a GOROOT for a vanilla go installation.