### PR TITLE
Add glojure.go.types package to ease creating go types

### DIFF
--- a/pkg/gen/gljimports/gljimports_darwin_amd64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_amd64.go
@@ -3439,6 +3439,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/lang.BooleanCast", github_com_glojurelang_glojure_pkg_lang.BooleanCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)).Elem())
 	_register("*github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/lang.BuiltinTypes", github_com_glojurelang_glojure_pkg_lang.BuiltinTypes)
 	_register("github.com/glojurelang/glojure/pkg/lang.Builtins", github_com_glojurelang_glojure_pkg_lang.Builtins)
 	_register("github.com/glojurelang/glojure/pkg/lang.ByteCast", github_com_glojurelang_glojure_pkg_lang.ByteCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Char", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Char)(nil)).Elem())

--- a/pkg/gen/gljimports/gljimports_darwin_arm64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_arm64.go
@@ -3439,6 +3439,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/lang.BooleanCast", github_com_glojurelang_glojure_pkg_lang.BooleanCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)).Elem())
 	_register("*github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/lang.BuiltinTypes", github_com_glojurelang_glojure_pkg_lang.BuiltinTypes)
 	_register("github.com/glojurelang/glojure/pkg/lang.Builtins", github_com_glojurelang_glojure_pkg_lang.Builtins)
 	_register("github.com/glojurelang/glojure/pkg/lang.ByteCast", github_com_glojurelang_glojure_pkg_lang.ByteCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Char", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Char)(nil)).Elem())

--- a/pkg/gen/gljimports/gljimports_linux_amd64.go
+++ b/pkg/gen/gljimports/gljimports_linux_amd64.go
@@ -3439,6 +3439,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/lang.BooleanCast", github_com_glojurelang_glojure_pkg_lang.BooleanCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)).Elem())
 	_register("*github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/lang.BuiltinTypes", github_com_glojurelang_glojure_pkg_lang.BuiltinTypes)
 	_register("github.com/glojurelang/glojure/pkg/lang.Builtins", github_com_glojurelang_glojure_pkg_lang.Builtins)
 	_register("github.com/glojurelang/glojure/pkg/lang.ByteCast", github_com_glojurelang_glojure_pkg_lang.ByteCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Char", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Char)(nil)).Elem())

--- a/pkg/gen/gljimports/gljimports_linux_arm64.go
+++ b/pkg/gen/gljimports/gljimports_linux_arm64.go
@@ -3439,6 +3439,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/lang.BooleanCast", github_com_glojurelang_glojure_pkg_lang.BooleanCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)).Elem())
 	_register("*github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/lang.BuiltinTypes", github_com_glojurelang_glojure_pkg_lang.BuiltinTypes)
 	_register("github.com/glojurelang/glojure/pkg/lang.Builtins", github_com_glojurelang_glojure_pkg_lang.Builtins)
 	_register("github.com/glojurelang/glojure/pkg/lang.ByteCast", github_com_glojurelang_glojure_pkg_lang.ByteCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Char", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Char)(nil)).Elem())

--- a/pkg/gen/gljimports/gljimports_windows.go
+++ b/pkg/gen/gljimports/gljimports_windows.go
@@ -3439,6 +3439,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/lang.BooleanCast", github_com_glojurelang_glojure_pkg_lang.BooleanCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)).Elem())
 	_register("*github.com/glojurelang/glojure/pkg/lang.Box", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Box)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/lang.BuiltinTypes", github_com_glojurelang_glojure_pkg_lang.BuiltinTypes)
 	_register("github.com/glojurelang/glojure/pkg/lang.Builtins", github_com_glojurelang_glojure_pkg_lang.Builtins)
 	_register("github.com/glojurelang/glojure/pkg/lang.ByteCast", github_com_glojurelang_glojure_pkg_lang.ByteCast)
 	_register("github.com/glojurelang/glojure/pkg/lang.Char", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_lang.Char)(nil)).Elem())

--- a/pkg/lang/builtins.go
+++ b/pkg/lang/builtins.go
@@ -6,8 +6,7 @@ import (
 )
 
 var (
-	Builtins = map[string]interface{}{
-		// Built-in types
+	BuiltinTypes = map[string]reflect.Type{
 		"any":        reflect.TypeOf((*interface{})(nil)).Elem(),
 		"bool":       reflect.TypeOf(false),
 		"uint8":      reflect.TypeOf(uint8(0)),
@@ -29,7 +28,9 @@ var (
 		"byte":       reflect.TypeOf(byte(0)),
 		"rune":       reflect.TypeOf(rune(0)),
 		"error":      reflect.TypeOf((*error)(nil)).Elem(),
+	}
 
+	Builtins = map[string]interface{}{
 		// Built-in functions
 		"append":  GoAppend,
 		"copy":    GoCopy,
@@ -70,6 +71,12 @@ var (
 		"recv":          GoRecv,        // recv(ch) -> val, ok <- ch
 	}
 )
+
+func init() {
+	for name, typ := range BuiltinTypes {
+		Builtins[name] = typ
+	}
+}
 
 func GoAppend(slc interface{}, vals ...interface{}) interface{} {
 	slcVal := reflect.ValueOf(slc)

--- a/pkg/stdlib/glojure/go/types.glj
+++ b/pkg/stdlib/glojure/go/types.glj
@@ -1,0 +1,98 @@
+(ns glojure.go.types)
+
+(defprotocol AstType
+  (ast->type [ast]))
+
+(defn- struct-field
+  ([type-ast] (struct-field type-ast nil))
+  ([type-ast name]
+   (let [typ (ast->type type-ast)
+         name (if (= "" name) nil name)
+         anonymous (nil? name)
+         name (or name (.Name typ))
+         sf (go/new reflect.StructField)]
+     (set! (.Type sf) typ)
+     (set! (.Name sf) name)
+     (when anonymous
+       (set! (.Anonymous sf) true))
+     (go/deref sf))))
+
+(extend-protocol AstType
+  *go$ast.Ident
+  (ast->type
+    [ast]
+    (let [name (.Name ast)
+          typ (get github.com$glojurelang$glojure$pkg$lang.BuiltinTypes name)]
+      (when-not typ (throw (fmt.Errorf "unknown type %s" name)))
+      typ))
+
+  *go$ast.ArrayType
+  (ast->type
+    [ast]
+    (let [len (.Len ast)
+          elt (ast->type (.Elt ast))]
+      (if len
+        (go/array-of (-> len .Value strconv.Atoi first) elt)
+        (go/slice-of elt))))
+
+  *go$ast.MapType
+  (ast->type
+    [ast]
+    (go/map-of (ast->type (.Key ast)) (ast->type (.Value ast))))
+
+  *go$ast.ChanType
+  (ast->type
+    [ast]
+    (let [dir (.Dir ast)
+          ctor (cond
+                 (= dir go$ast.SEND) go/chan<--of
+                 (= dir go$ast.RECV) go/<-chan-of
+                 :else go/chan-of)]
+      (ctor (ast->type (.Value ast)))))
+
+  *go$ast.FuncType
+  (ast->type
+    [ast]
+    (let [pl (or (.Params ast) nil)
+          params (and pl
+                      (->> (.List pl)
+                           (map #(repeat (max 1 (go/len (.Names %))) (.Type %)))
+                           (apply concat)))
+          last-param (last params)
+          variadic (instance? *go$ast.Ellipsis last-param)
+          params (if-not variadic
+                   (map ast->type params)
+                   (concat (map ast->type (butlast params))
+                           [(go/slice-of (ast->type (.Elt last-param)))]))
+          rl (or (.Results ast) nil)
+          results (and rl
+                       (->> (.List rl)
+                            (map #(repeat (max 1 (go/len (.Names %))) (.Type %)))
+                            (apply concat)
+                            (map ast->type)))]
+    (go/func-of params results variadic)))
+
+  *go$ast.StructType
+  (ast->type
+    [ast]
+    (let [fields (.. ast Fields List)
+          struct-fields (->> fields
+                             (map (fn [f]
+                                    (let [names (map #(.Name %) (.Names f))
+                                          type (.Type f)
+                                          tag (.Type f)]
+                                      (cond
+                                        (empty? names) [(struct-field type)]
+                                        (= 1 (count names)) [(struct-field type (first names))]
+                                        :else (map #(struct-field type %) names)))))
+                             (apply concat))]
+      (reflect.StructOf struct-fields)))
+  )
+
+(defn from-string
+  "Returns a Go type from a go type expression."
+  [typ]
+  (if-not (string? typ) (throw (fmt.Errorf "from-string: argument must be a string, got %T" typ)))
+  (let [[ast err] (go$parser.ParseExpr typ)]
+    (if err (throw (fmt.Errorf "from-string: invalid type string '%s': %w" typ err)))
+    (ast->type ast)))


### PR DESCRIPTION
For example, instead of this:
```clojure
(go/ptr-to (go/map-of go/string go/any))
```

one can do
```clojure
;; assume glojure.go.types has been required as gt
(gt/from-string "*map[string]any")
```

Only builtin types are supported.