### PR TITLE
Fix test/glojure/test_glojure/numbers.glj failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ STDLIB := $(STDLIB_ORIGINALS:scripts/rewrite-core/originals/%=%)
 STDLIB_ORIGINALS := $(addprefix scripts/rewrite-core/originals/,$(STDLIB))
 STDLIB_TARGETS := $(addprefix pkg/stdlib/glojure/,$(STDLIB:.clj=.glj))
 
-TEST_FILES := $(shell find ./test -name '*.glj')
+TEST_FILES := $(shell find ./test -name '*.glj' | sort)
 TEST_TARGETS := $(addsuffix .test,$(TEST_FILES))
 
 GOPLATFORMS := darwin_arm64 darwin_amd64 linux_arm64 linux_amd64 windows_amd64 windows_arm js_wasm

--- a/test/glojure/test_glojure/numbers.glj
+++ b/test/glojure/test_glojure/numbers.glj
@@ -143,17 +143,17 @@
    [:input           [-1            0           1           math.MaxInt8  math.MaxInt16  math.MaxInt32        math.MaxInt64         math.MaxFloat32    math.MaxFloat64]]
    [char             [:error        (char 0)    (char 1)    (char 127)    (char 32767)   :error               :error                :error             :error]]
    ;; In go, char == rune, which is equivalent to int32
-   [unchecked-char   [(Char -1)     (Char 0)    (Char 1)    (Char 127)    (Char 32767)   (Char math.MaxInt32) (Char -1)             (Char -1)          (Char -1)]]
+   [unchecked-char   [(Char -1)     (Char 0)    (Char 1)    (Char 127)    (Char 32767)   (Char math.MaxInt32) (Char -1)             (Char 0)            (Char 0)]]
    ;; bytes are unsigned in go
    [byte             [255           0           1           math.MaxInt8  :error         :error               :error                :error             :error]]
    ;; bytes are unsigned in go
-   [unchecked-byte   [255           0           1           math.MaxInt8  255            255                  255                   255                255]]
+   [unchecked-byte   [255           0           1           math.MaxInt8  255            255                  255                   0                 0]]
    [short            [-1            0           1           math.MaxInt8  math.MaxInt16  :error               :error                :error             :error]]
-   [unchecked-short  [-1            0           1           math.MaxInt8  math.MaxInt16  -1                   -1                    -1                 -1]]
+   [unchecked-short  [-1            0           1           math.MaxInt8  math.MaxInt16  -1                   -1                    0                 0]]
    [int              [-1            0           1           math.MaxInt8  math.MaxInt16  math.MaxInt32        max-int-res           :error             :error]]
-   [unchecked-int    [-1            0           1           math.MaxInt8  math.MaxInt16  math.MaxInt32        max-int-res           max-int-res        max-int-res]]
+   [unchecked-int    [-1            0           1           math.MaxInt8  math.MaxInt16  math.MaxInt32        max-int-res           -9223372036854775808 -9223372036854775808]]
    [long             [-1            0           1           math.MaxInt8  math.MaxInt16  math.MaxInt32        math.MaxInt64         :error             :error]]
-   [unchecked-long   [-1            0           1           math.MaxInt8  math.MaxInt16  math.MaxInt32        math.MaxInt64         math.MaxInt64      math.MaxInt64]]
+   [unchecked-long   [-1            0           1           math.MaxInt8  math.MaxInt16  math.MaxInt32        math.MaxInt64         -9223372036854775808 -9223372036854775808]]
                                                                                              ;; 2.14748365E9 if when float/double conversion is avoided...
    [float            [-1.0          0.0         1.0         127.0         32767.0        2.147483648E9        9.223372036854776E18  math.MaxFloat32    :error]]
    [unchecked-float  [-1.0          0.0         1.0         127.0         32767.0        2.147483648E9        9.223372036854776E18  math.MaxFloat32    (go/float32 (math.Inf 1))]]


### PR DESCRIPTION
I'm not sure why tests were failing since they pass here: https://github.com/glojurelang/glojure/actions
But this fixed it for me locally and still passing here: https://github.com/ingydotnet/glojure/actions


After this patch:

```
$ ./bin/linux_amd64/glj test/glojure/test_glojure/numbers.glj

Testing glojure.test-glojure.numbers

Ran 42 tests containing 2744 assertions.
0 failures, 0 errors.
```

Before this patch:

```
$ ./bin/linux_amd64/glj test/glojure/test_glojure/numbers.glj

Testing glojure.test-glojure.numbers

FAIL in (nil) (:)
expected: (= vals (map wrapped inputs))
  actual: (not (= [\� \ \ \ \� \� \� \� \�] (\� \ \ \ \� \� \� \ \)))

FAIL in (nil) (:)
expected: (= vals (map wrapped inputs))
  actual: (not (= [255 0 1 127 255 255 255 255 255] (255 0 1 127 255 255 255 0 0)))

FAIL in (nil) (:)
expected: (= vals (map wrapped inputs))
  actual: (not (= [-1 0 1 127 32767 -1 -1 -1 -1] (-1 0 1 127 32767 -1 -1 0 0)))

FAIL in (nil) (:)
expected: (= vals (map wrapped inputs))
  actual: (not (= [-1 0 1 127 32767 2147483647 9223372036854775807 9223372036854775807 9223372036854775807] (-1 0 1 127 32767 2147483647 9223372036854775807 -9223372036854775808 -9223372

FAIL in (nil) (:)
expected: (= vals (map wrapped inputs))
  actual: (not (= [-1 0 1 127 32767 2147483647 9223372036854775807 9223372036854775807 9223372036854775807] (-1 0 1 127 32767 2147483647 9223372036854775807 -9223372036854775808 -9223372

Ran 42 tests containing 2744 assertions.
5 failures, 0 errors.
```
