### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,19 +30,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - uses: cachix/install-nix-action@v19
+        uses: actions/configure-pages@v4
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Build WASM
         run: nix-shell --run 'PATH=$(go env GOPATH)/bin:$PATH make bin/js_wasm/glj.wasm && cp bin/js_wasm/glj.wasm doc/repl/'
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './doc/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Deploys of the static site are [failing](https://github.com/glojurelang/glojure/actions/runs/16690742761/job/47248121122) due to outdated actions. Upgrade.

- actions/checkout: v3 → v4
- actions/configure-pages: v3 → v4
- cachix/install-nix-action: v19 → v31
- actions/upload-pages-artifact: v2 → v3
- actions/deploy-pages: v2 → v4

This resolves compatibility issues with deprecated action versions and ensures the workflow uses the latest supported versions.