### PR TITLE
Add command line options for glj -e --version --help -h 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The `glj` command provides a traditional Clojure development experience:
 
 **Start a REPL (interactive session):**
 ```
+user=> *glojure-version*
+{:major 0, :minor 3, :incremental 0, :qualifier nil}
 $ glj
 user=> (+ 1 2 3)
 6

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ embedded within Go applications.
 
 The `glj` command provides a traditional Clojure development experience:
 
+**Show the version:**
+```
+$ glj --version
+glojure v0.3.0
+```
+
 **Start a REPL (interactive session):**
 ```
 user=> *glojure-version*

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ embedded within Go applications.
 
 The `glj` command provides a traditional Clojure development experience:
 
+**Show the help:**
+```
+$ glj --help   # or glj -h
+```
+
 **Show the version:**
 ```
 $ glj --version

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ![example workflow](https://github.com/glojurelang/glojure/actions/workflows/ci.yml/badge.svg)
 
-[Try it in your browser!](https://glojurelang.github.io/glojure/) (fair warning: startup on the web is slow)
+[Try it in your browser!](https://glojurelang.github.io/glojure/)
+(fair warning: startup on the web is slow)
 
 <img alt="Gopher image" src="./doc/logo.png" width="512" />
 
@@ -51,7 +52,8 @@ user=>
 
 ## Usage
 
-Glojure can be used in two ways: as a standalone command-line tool (`glj`) or embedded within Go applications.
+Glojure can be used in two ways: as a standalone command-line tool (`glj`) or
+embedded within Go applications.
 
 ### Using the `glj` Command
 
@@ -65,6 +67,18 @@ user=> (+ 1 2 3)
 user=> (println "Hello from Glojure!")
 Hello from Glojure!
 nil
+```
+
+**Evaluate expressions:**
+```
+$ glj -e '(println "Hello, World!")'
+Hello, World!
+$ glj -e '(apply + (range 3 10))'
+42
+$ glj -e '
+(defn factorial [n] (if (<= n 1) 1 (* n (factorial (dec n)))))
+(factorial 5)'
+120
 ```
 
 **Run a Clojure script:**
@@ -100,7 +114,8 @@ Server starting on :8080...
 
 ### Embedding Glojure in Go Applications
 
-You can also embed Glojure as a scripting language within your Go applications. This is useful when you want to:
+You can also embed Glojure as a scripting language within your Go applications.
+This is useful when you want to:
 - Add scriptable configuration to your Go application
 - Allow users to extend your application with Clojure plugins
 - Mix Go's performance with Clojure's expressiveness
@@ -185,6 +200,7 @@ runtime.ReadEval(`
 - Writing standalone Clojure programs
 - Interactive development with the REPL
 - Running Clojure scripts
+- Evaluating expressions directly from the command line
 - Learning Clojure with Go interop
 
 **Embed Glojure for:**

--- a/pkg/gljmain/gljmain.go
+++ b/pkg/gljmain/gljmain.go
@@ -2,8 +2,10 @@ package gljmain
 
 import (
 	"bufio"
+	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	// bootstrap the runtime
 	_ "github.com/glojurelang/glojure/pkg/glj"
@@ -19,15 +21,50 @@ func Main(args []string) {
 
 	if len(args) == 0 {
 		repl.Start()
+	} else if args[0] == "-e" {
+		// Evaluate expression from command line
+		if len(args) < 2 {
+			log.Fatal("glj: -e requires an expression")
+		}
+		expr := args[1]
+		env := lang.GlobalEnv
+
+		// Set command line args (everything after -e and the expression)
+		core := lang.FindNamespace(lang.NewSymbol("glojure.core"))
+		core.FindInternedVar(lang.NewSymbol("*command-line-args*")).BindRoot(lang.Seq(args[2:]))
+
+		rdr := reader.New(strings.NewReader(expr), reader.WithGetCurrentNS(func() *lang.Namespace {
+			return env.CurrentNamespace()
+		}))
+		var lastResult interface{}
+		for {
+			val, err := rdr.ReadOne()
+			if err == reader.ErrEOF {
+				break
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+			result, err := env.Eval(val)
+			if err != nil {
+				log.Fatal(err)
+			}
+			lastResult = result
+		}
+		// Print only the final result unless it's nil
+		if !lang.IsNil(lastResult) {
+			fmt.Println(lang.PrintString(lastResult))
+		}
 	} else {
-		file, err := os.Open(os.Args[1])
+		// Execute file
+		file, err := os.Open(args[0])
 		if err != nil {
 			log.Fatal(err)
 		}
 		env := lang.GlobalEnv
 
 		core := lang.FindNamespace(lang.NewSymbol("glojure.core"))
-		core.FindInternedVar(lang.NewSymbol("*command-line-args*")).BindRoot(lang.Seq(os.Args[2:]))
+		core.FindInternedVar(lang.NewSymbol("*command-line-args*")).BindRoot(lang.Seq(args[1:]))
 
 		rdr := reader.New(bufio.NewReader(file), reader.WithGetCurrentNS(func() *lang.Namespace {
 			return env.CurrentNamespace()

--- a/pkg/gljmain/gljmain.go
+++ b/pkg/gljmain/gljmain.go
@@ -16,6 +16,27 @@ import (
 	"github.com/glojurelang/glojure/pkg/runtime"
 )
 
+func printHelp() {
+	fmt.Printf(`Glojure v%s
+
+Usage: glj [options] [file]
+
+Options:
+  -e <expr>        Evaluate expression from command line
+  -h, --help       Show this help message
+  --version        Show version information
+
+Examples:
+  glj                   # Start REPL
+  glj -e "(+ 1 2)"      # Evaluate expression
+  glj script.glj        # Run script file
+  glj --version         # Show version
+  glj --help            # Show this help
+
+For more information, visit: https://github.com/glojurelang/glojure
+`, runtime.VERSION)
+}
+
 func Main(args []string) {
 	runtime.AddLoadPath(os.DirFS("."))
 
@@ -23,6 +44,9 @@ func Main(args []string) {
 		repl.Start()
 	} else if args[0] == "--version" {
 		fmt.Printf("glojure v%s\n", runtime.VERSION)
+		return
+	} else if args[0] == "--help" || args[0] == "-h" {
+		printHelp()
 		return
 	} else if args[0] == "-e" {
 		// Evaluate expression from command line

--- a/pkg/gljmain/gljmain.go
+++ b/pkg/gljmain/gljmain.go
@@ -21,6 +21,9 @@ func Main(args []string) {
 
 	if len(args) == 0 {
 		repl.Start()
+	} else if args[0] == "--version" {
+		fmt.Printf("glojure v%s\n", runtime.VERSION)
+		return
 	} else if args[0] == "-e" {
 		// Evaluate expression from command line
 		if len(args) < 2 {

--- a/pkg/runtime/environment.go
+++ b/pkg/runtime/environment.go
@@ -63,6 +63,7 @@ func newEnvironment(ctx context.Context, stdout, stderr io.Writer) *environment 
 		"print-meta",
 		"print-dup",
 		"read-eval",
+		"glojure-version",
 	} {
 		coreNS.InternWithValue(lang.NewSymbol("*"+dyn+"*"), nil, true).SetDynamic()
 	}

--- a/test/glojure/test_glojure/cli.glj
+++ b/test/glojure/test_glojure/cli.glj
@@ -9,11 +9,11 @@
   acts like a comment and the forms are run unchanged."
   [purpose & test-forms]
   (let [tests (map
-                #(if (= (:ns (meta (resolve (first %))))
-                        (the-ns 'glojure.test))
-                   (concat % (list purpose))
-                   %)
-                test-forms)]
+               #(if (= (:ns (meta (resolve (first %))))
+                       (the-ns 'glojure.test))
+                  (concat % (list purpose))
+                  %)
+               test-forms)]
     `(do ~@tests)))
 
 (defn run-cli-cmd [& args]
@@ -52,6 +52,26 @@
    (let [[out err] (run-cli-cmd glj "-e" "*glojure-version*")]
      (is (= out "{:major 0, :minor 3, :incremental 0, :qualifier nil}\n")
          "Version should match expected format")
+     (is (empty? err) "Command should not return an error"))))
+
+(deftest help-flag-test
+  (test-that
+   "glj --help flag works correctly"
+   (let [[out err] (run-cli-cmd glj "--help")]
+     (is (re-matches
+          #"(?s).*Glojure v0\.3\.0.*Usage: glj.*Options:.*-e.*-h.*--help.*--version.*Examples:.*"
+          out)
+         "Command should output help information")
+     (is (empty? err) "Command should not return an error"))))
+
+(deftest short-help-flag-test
+  (test-that
+   "glj -h flag works correctly"
+   (let [[out err] (run-cli-cmd glj "-h")]
+     (is (re-matches
+          #"(?s).*Glojure v0\.3\.0.*Usage: glj.*Options:.*-e.*-h.*--help.*--version.*Examples:.*"
+          out)
+         "Command should output help information")
      (is (empty? err) "Command should not return an error"))))
 
 (run-tests)

--- a/test/glojure/test_glojure/cli.glj
+++ b/test/glojure/test_glojure/cli.glj
@@ -1,0 +1,41 @@
+(ns glojure.test-glojure.cli
+  (:use glojure.test)
+  (:require [glojure.string :as str]))
+
+(defmacro #^{:private true} test-that
+  "Provides a useful way for specifying the purpose of tests. If the first-level
+  forms are lists that make a call to a glojure.test function, it supplies the
+  purpose as the msg argument to those functions. Otherwise, the purpose just
+  acts like a comment and the forms are run unchanged."
+  [purpose & test-forms]
+  (let [tests (map
+                #(if (= (:ns (meta (resolve (first %))))
+                        (the-ns 'glojure.test))
+                   (concat % (list purpose))
+                   %)
+                test-forms)]
+    `(do ~@tests)))
+
+(defn run-cli-cmd [& args]
+  (let [bytes-to-string (fn [bytes]
+                          (apply str (map char (seq bytes))))
+        cmd (apply os$exec.Command args)
+        [output err] (.CombinedOutput cmd)]
+    [(bytes-to-string output) (bytes-to-string err)]))
+
+(defn find-glj-bin []
+  (let [[out err] (run-cli-cmd "find" "bin" "-name" "glj")]
+    (if (and (seq out) (empty? err))
+      (first (str/split-lines out))
+      (throw (Exception. (str "Failed to find glj bin: " err))))))
+
+(def glj (find-glj-bin))
+
+(deftest e-flag-test
+  (test-that
+   "glj -e flag works correctly"
+   (let [[out err] (run-cli-cmd glj "-e" "(* 6 7)")]
+     (is (= out "42\n") "Command should output 42")
+     (is (empty? err) "Command should not return an error"))))
+
+(run-tests)

--- a/test/glojure/test_glojure/cli.glj
+++ b/test/glojure/test_glojure/cli.glj
@@ -18,24 +18,32 @@
 
 (defn run-cli-cmd [& args]
   (let [bytes-to-string (fn [bytes]
-                          (apply str (map char (seq bytes))))
+                          (if (nil? bytes)
+                            ""
+                            (apply str (map char (seq bytes)))))
         cmd (apply os$exec.Command args)
         [output err] (.CombinedOutput cmd)]
     [(bytes-to-string output) (bytes-to-string err)]))
 
-(defn find-glj-bin []
-  (let [[out err] (run-cli-cmd "find" "bin" "-name" "glj")]
+(def glj
+  (let [[out err] (run-cli-cmd "find" "bin" "-name" "glj" "-executable")]
     (if (and (seq out) (empty? err))
       (first (str/split-lines out))
       (throw (Exception. (str "Failed to find glj bin: " err))))))
-
-(def glj (find-glj-bin))
 
 (deftest e-flag-test
   (test-that
    "glj -e flag works correctly"
    (let [[out err] (run-cli-cmd glj "-e" "(* 6 7)")]
      (is (= out "42\n") "Command should output 42")
+     (is (empty? err) "Command should not return an error"))))
+
+(deftest glojure-version-test
+  (test-that
+   "*glojure-version* should be set correctly"
+   (let [[out err] (run-cli-cmd glj "-e" "*glojure-version*")]
+     (is (= out "{:major 0, :minor 3, :incremental 0, :qualifier nil}\n")
+         "Version should match expected format")
      (is (empty? err) "Command should not return an error"))))
 
 (run-tests)

--- a/test/glojure/test_glojure/cli.glj
+++ b/test/glojure/test_glojure/cli.glj
@@ -38,6 +38,14 @@
      (is (= out "42\n") "Command should output 42")
      (is (empty? err) "Command should not return an error"))))
 
+(deftest version-flag-test
+  (test-that
+   "glj --version flag works correctly"
+   (let [[out err] (run-cli-cmd glj "--version")]
+     (is (re-matches #"glojure v\d+\.\d+\.\d+\n" out)
+         "Command should output version")
+     (is (empty? err) "Command should not return an error"))))
+
 (deftest glojure-version-test
   (test-that
    "*glojure-version* should be set correctly"


### PR DESCRIPTION
Started by adding `glj -e ...` support. Much like `bb -e ...` or `cj -M -e ...`.

Added `*glojure-version*` variable support.
This supports `glj --version`.

Added `--help` and `-h` for good measure.

CLI tests for all.

Had to adjust Makefile to build `bin/.../glj` binary to test stdout of CLI commands.

Added `build` and `clean` Makefile targets to be complete.