### PR TITLE
Add glj_no_aot_stdlib build tag to omit aot stdlib

### DIFF
--- a/pkg/glj/init-aot.go
+++ b/pkg/glj/init-aot.go
@@ -1,0 +1,11 @@
+//go:build !glj_no_aot_stdlib
+
+package glj
+
+import (
+	// Add NS loaders for the standard library.
+	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/core"
+	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/core/async"
+	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/go/io"
+	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/protocols"
+)

--- a/pkg/glj/init.go
+++ b/pkg/glj/init.go
@@ -8,12 +8,6 @@ import (
 	_ "github.com/glojurelang/glojure/pkg/gen/gljimports"
 	"github.com/glojurelang/glojure/pkg/lang"
 
-	// Add NS loaders for the standard library.
-	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/core"
-	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/core/async"
-	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/go/io"
-	_ "github.com/glojurelang/glojure/pkg/stdlib/glojure/protocols"
-
 	"github.com/glojurelang/glojure/pkg/runtime"
 )
 

--- a/pkg/runtime/envinit.go
+++ b/pkg/runtime/envinit.go
@@ -120,7 +120,7 @@ func NewEnvironment(opts ...EvalOption) lang.Environment {
 	// Workaround to ensure namespaces that are required by core are loaded.
 	// TODO: AOT should identify this dependency and generate code to load it.
 	if useAot {
-		RT.Load("glojure/core/protocols")
+		RT.Load("glojure/protocols")
 		RT.Load("glojure/string")
 		RT.Load("glojure/go/io")
 	}


### PR DESCRIPTION
`go build --tags glj_no_aot_stdlib` builds glojure without the AOT go standard library.