### PR TITLE
Remove warning about web startup speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![example workflow](https://github.com/glojurelang/glojure/actions/workflows/ci.yml/badge.svg)
 
 [Try it in your browser!](https://glojurelang.github.io/glojure/)
-(fair warning: startup on the web is slow)
 
 <img alt="Gopher image" src="./doc/logo.png" width="512" />
 


### PR DESCRIPTION
It's reasonably fast now now that the standard library is compiled AOT.