### PR TITLE
Add support for GLJPATH, remove GLOJURE_STDLIB_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ generate:
 	go generate ./...
 
 aot: gocmd $(STDLIB-TARGETS)
-	GLOJURE_USE_AOT=false \
-	GLOJURE_STDLIB_PATH=./pkg/stdlib \
+	GLJ_USE_AOT=false \
+	GLJPATH=./pkg/stdlib \
 	$(GO-CMD) run -tags glj_no_aot_stdlib ./cmd/glj \
 	<<<"(map compile '[$(AOT-NAMESPACES)])"
 

--- a/pkg/gen/gljimports/gljimports_darwin_amd64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_amd64.go
@@ -3999,6 +3999,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Fn", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Fn)(nil)))
 	_register("github.com/glojurelang/glojure/pkg/runtime.Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)).Elem())
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/runtime.GetLoadPath", github_com_glojurelang_glojure_pkg_runtime.GetLoadPath)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetNSLoader", github_com_glojurelang_glojure_pkg_runtime.GetNSLoader)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetUseAOT", github_com_glojurelang_glojure_pkg_runtime.GetUseAOT)
 	_register("github.com/glojurelang/glojure/pkg/runtime.NewEnvironment", github_com_glojurelang_glojure_pkg_runtime.NewEnvironment)

--- a/pkg/gen/gljimports/gljimports_darwin_arm64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_arm64.go
@@ -3999,6 +3999,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Fn", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Fn)(nil)))
 	_register("github.com/glojurelang/glojure/pkg/runtime.Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)).Elem())
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/runtime.GetLoadPath", github_com_glojurelang_glojure_pkg_runtime.GetLoadPath)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetNSLoader", github_com_glojurelang_glojure_pkg_runtime.GetNSLoader)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetUseAOT", github_com_glojurelang_glojure_pkg_runtime.GetUseAOT)
 	_register("github.com/glojurelang/glojure/pkg/runtime.NewEnvironment", github_com_glojurelang_glojure_pkg_runtime.NewEnvironment)

--- a/pkg/gen/gljimports/gljimports_js_wasm.go
+++ b/pkg/gen/gljimports/gljimports_js_wasm.go
@@ -3999,6 +3999,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Fn", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Fn)(nil)))
 	_register("github.com/glojurelang/glojure/pkg/runtime.Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)).Elem())
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/runtime.GetLoadPath", github_com_glojurelang_glojure_pkg_runtime.GetLoadPath)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetNSLoader", github_com_glojurelang_glojure_pkg_runtime.GetNSLoader)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetUseAOT", github_com_glojurelang_glojure_pkg_runtime.GetUseAOT)
 	_register("github.com/glojurelang/glojure/pkg/runtime.NewEnvironment", github_com_glojurelang_glojure_pkg_runtime.NewEnvironment)

--- a/pkg/gen/gljimports/gljimports_linux_amd64.go
+++ b/pkg/gen/gljimports/gljimports_linux_amd64.go
@@ -3999,6 +3999,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Fn", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Fn)(nil)))
 	_register("github.com/glojurelang/glojure/pkg/runtime.Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)).Elem())
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/runtime.GetLoadPath", github_com_glojurelang_glojure_pkg_runtime.GetLoadPath)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetNSLoader", github_com_glojurelang_glojure_pkg_runtime.GetNSLoader)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetUseAOT", github_com_glojurelang_glojure_pkg_runtime.GetUseAOT)
 	_register("github.com/glojurelang/glojure/pkg/runtime.NewEnvironment", github_com_glojurelang_glojure_pkg_runtime.NewEnvironment)

--- a/pkg/gen/gljimports/gljimports_linux_arm64.go
+++ b/pkg/gen/gljimports/gljimports_linux_arm64.go
@@ -3999,6 +3999,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Fn", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Fn)(nil)))
 	_register("github.com/glojurelang/glojure/pkg/runtime.Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)).Elem())
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/runtime.GetLoadPath", github_com_glojurelang_glojure_pkg_runtime.GetLoadPath)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetNSLoader", github_com_glojurelang_glojure_pkg_runtime.GetNSLoader)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetUseAOT", github_com_glojurelang_glojure_pkg_runtime.GetUseAOT)
 	_register("github.com/glojurelang/glojure/pkg/runtime.NewEnvironment", github_com_glojurelang_glojure_pkg_runtime.NewEnvironment)

--- a/pkg/gen/gljimports/gljimports_windows_amd64.go
+++ b/pkg/gen/gljimports/gljimports_windows_amd64.go
@@ -3999,6 +3999,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Fn", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Fn)(nil)))
 	_register("github.com/glojurelang/glojure/pkg/runtime.Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)).Elem())
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/runtime.GetLoadPath", github_com_glojurelang_glojure_pkg_runtime.GetLoadPath)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetNSLoader", github_com_glojurelang_glojure_pkg_runtime.GetNSLoader)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetUseAOT", github_com_glojurelang_glojure_pkg_runtime.GetUseAOT)
 	_register("github.com/glojurelang/glojure/pkg/runtime.NewEnvironment", github_com_glojurelang_glojure_pkg_runtime.NewEnvironment)

--- a/pkg/gen/gljimports/gljimports_windows_arm.go
+++ b/pkg/gen/gljimports/gljimports_windows_arm.go
@@ -3999,6 +3999,7 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Fn", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Fn)(nil)))
 	_register("github.com/glojurelang/glojure/pkg/runtime.Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)).Elem())
 	_register("github.com/glojurelang/glojure/pkg/runtime.*Generator", reflect.TypeOf((*github_com_glojurelang_glojure_pkg_runtime.Generator)(nil)))
+	_register("github.com/glojurelang/glojure/pkg/runtime.GetLoadPath", github_com_glojurelang_glojure_pkg_runtime.GetLoadPath)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetNSLoader", github_com_glojurelang_glojure_pkg_runtime.GetNSLoader)
 	_register("github.com/glojurelang/glojure/pkg/runtime.GetUseAOT", github_com_glojurelang_glojure_pkg_runtime.GetUseAOT)
 	_register("github.com/glojurelang/glojure/pkg/runtime.NewEnvironment", github_com_glojurelang_glojure_pkg_runtime.NewEnvironment)

--- a/pkg/gljmain/gljmain.go
+++ b/pkg/gljmain/gljmain.go
@@ -38,8 +38,6 @@ For more information, visit: https://github.com/glojurelang/glojure
 }
 
 func Main(args []string) {
-	runtime.AddLoadPath(os.DirFS("."))
-
 	if len(args) == 0 {
 		repl.Start()
 	} else if args[0] == "--version" {

--- a/pkg/runtime/codegen_test.go
+++ b/pkg/runtime/codegen_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestCodegen(t *testing.T) {
 	if runtime.GetUseAOT() {
-		t.Skip("Skipping codegen tests with AOT enabled; run with GLOJURE_USE_AOT=0")
+		t.Skip("Skipping codegen tests with AOT enabled; run with GLJ_USE_AOT=0")
 	}
 
 	var testFiles []string

--- a/pkg/runtime/envinit.go
+++ b/pkg/runtime/envinit.go
@@ -145,6 +145,17 @@ func NewEnvironment(opts ...EvalOption) lang.Environment {
 		versionVar.BindRoot(parseVersion(Version))
 	}
 
+	// Set the load path
+	loadPathVar := core.FindInternedVar(lang.NewSymbol("*load-path*"))
+	if loadPathVar != nil {
+		pathStrings := GetLoadPath()
+		pathValues := make([]any, len(pathStrings))
+		for i, path := range pathStrings {
+			pathValues[i] = path
+		}
+		loadPathVar.BindRoot(lang.NewVector(pathValues...))
+	}
+
 	lang.InternVar(core, lang.NewSymbol("load-file"), func(filename string) any {
 		buf, err := os.ReadFile(filename)
 		if err != nil {

--- a/pkg/runtime/environment.go
+++ b/pkg/runtime/environment.go
@@ -64,6 +64,7 @@ func newEnvironment(ctx context.Context, stdout, stderr io.Writer) *environment 
 		"print-dup",
 		"read-eval",
 		"glojure-version",
+		"load-path",
 	} {
 		coreNS.InternWithValue(lang.NewSymbol("*"+dyn+"*"), nil, true).SetDynamic()
 	}

--- a/pkg/runtime/loadpath_test.go
+++ b/pkg/runtime/loadpath_test.go
@@ -1,0 +1,69 @@
+package runtime_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/glojurelang/glojure/pkg/runtime"
+)
+
+func TestGetLoadPath(t *testing.T) {
+	// Test that GetLoadPath returns a valid slice of strings
+	paths := runtime.GetLoadPath()
+	if len(paths) == 0 {
+		t.Fatal("GetLoadPath returned empty slice")
+	}
+
+	// Should contain at least the current directory and stdlib
+	foundCurrent := false
+	foundStdlib := false
+	for _, path := range paths {
+		if path == "." {
+			foundCurrent = true
+		}
+		if path == "<StdLib>" || strings.Contains(path, "stdlib") {
+			foundStdlib = true
+		}
+	}
+
+	if !foundCurrent {
+		t.Error("Load path should contain current directory '.'")
+	}
+	if !foundStdlib {
+		t.Error("Load path should contain stdlib")
+	}
+}
+
+func TestGLJPATHEnvironmentVariable(t *testing.T) {
+	// This test would need to be run in a subprocess to avoid affecting
+	// the global loadPath, but for now we'll just verify the structure
+	paths := runtime.GetLoadPath()
+
+	// Verify all paths are strings
+	for i, path := range paths {
+		if path == "" {
+			t.Errorf("Path at index %d is empty", i)
+		}
+	}
+
+	// The expected order is:
+	// [...GLJPATH dirs, current dir, <StdLib>]
+	if len(paths) > 0 {
+		// Last element should always be <StdLib>
+		last := paths[len(paths)-1]
+		if last != "<StdLib>" {
+			t.Errorf("Last path should be '<StdLib>', got: %s", last)
+		}
+
+		// If no GLJPATH, order should be [current dir, <StdLib>]
+		if os.Getenv("GLJPATH") == "" {
+			if len(paths) >= 2 {
+				secondToLast := paths[len(paths)-2]
+				if secondToLast != "." {
+					t.Errorf("Second to last path should be '.', got: %s", secondToLast)
+				}
+			}
+		}
+	}
+}

--- a/pkg/stdlib/clojure/core/loader.go
+++ b/pkg/stdlib/clojure/core/loader.go
@@ -68,6 +68,7 @@ func LoadNS() {
 	sym__STAR_flush_DASH_on_DASH_newline_STAR_ := lang.NewSymbol("*flush-on-newline*")
 	sym__STAR_glojure_DASH_version_STAR_ := lang.NewSymbol("*glojure-version*")
 	sym__STAR_in_STAR_ := lang.NewSymbol("*in*")
+	sym__STAR_load_DASH_path_STAR_ := lang.NewSymbol("*load-path*")
 	sym__STAR_loaded_DASH_libs_STAR_ := lang.NewSymbol("*loaded-libs*")
 	sym__STAR_loading_DASH_verbosely_STAR_ := lang.NewSymbol("*loading-verbosely*")
 	sym__STAR_ns_STAR_ := lang.NewSymbol("*ns*")
@@ -1465,6 +1466,8 @@ func LoadNS() {
 	var_clojure_DOT_core__STAR_glojure_DASH_version_STAR_ := lang.InternVarName(sym_clojure_DOT_core, sym__STAR_glojure_DASH_version_STAR_)
 	// var clojure.core/*in*
 	var_clojure_DOT_core__STAR_in_STAR_ := lang.InternVarName(sym_clojure_DOT_core, sym__STAR_in_STAR_)
+	// var clojure.core/*load-path*
+	var_clojure_DOT_core__STAR_load_DASH_path_STAR_ := lang.InternVarName(sym_clojure_DOT_core, sym__STAR_load_DASH_path_STAR_)
 	// var clojure.core/*loaded-libs*
 	var_clojure_DOT_core__STAR_loaded_DASH_libs_STAR_ := lang.InternVarName(sym_clojure_DOT_core, sym__STAR_loaded_DASH_libs_STAR_)
 	// var clojure.core/*loading-verbosely*
@@ -3131,6 +3134,14 @@ func LoadNS() {
 		var_clojure_DOT_core__STAR_glojure_DASH_version_STAR_ = ns.InternWithValue(tmp0, lang.NewMap(kw_major, int(0), kw_minor, int(0), kw_incremental, int(0), kw_qualifier, nil), true)
 		if tmp0.Meta() != nil {
 			var_clojure_DOT_core__STAR_glojure_DASH_version_STAR_.SetMeta(tmp0.Meta().(lang.IPersistentMap))
+		}
+	}
+	// *load-path*
+	{
+		tmp0 := sym__STAR_load_DASH_path_STAR_.WithMeta(lang.NewMap()).(*lang.Symbol)
+		var_clojure_DOT_core__STAR_load_DASH_path_STAR_ = ns.InternWithValue(tmp0, lang.NewVector("./pkg/stdlib", ".", "<StdLib>"), true)
+		if tmp0.Meta() != nil {
+			var_clojure_DOT_core__STAR_load_DASH_path_STAR_.SetMeta(tmp0.Meta().(lang.IPersistentMap))
 		}
 	}
 	// *loaded-libs*


### PR DESCRIPTION
Works for general use and for AOT.

```
$ (for f in a/a.glj b/b.glj x.glj; do (set -x; cat $f); done)
+ cat a/a.glj
(ns a)
(println "aaa")
+ cat b/b.glj
(ns b)
(println "bbb")
+ cat x.glj
(require 'a)
(require 'b)
(println "xxx")
$ GLJPATH=a:b ./bin/linux_amd64/glj x.glj 
aaa
bbb
xxx
$ 
```