### PR TITLE
Add CanSeq function and fix seqable?

### DIFF
--- a/pkg/lang/seq.go
+++ b/pkg/lang/seq.go
@@ -43,6 +43,22 @@ func IsSeq(x interface{}) bool {
 	return ok
 }
 
+func CanSeq(x interface{}) bool {
+	switch x.(type) {
+	case *EmptyList, *LazySeq, ISeq, Seqable, string, nil:
+		return true
+	}
+	t := reflect.TypeOf(x)
+	if t == nil {
+		return true
+	}
+	switch t.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return true
+	}
+	return false
+}
+
 func Seq(x interface{}) ISeq {
 	switch x := x.(type) {
 	case *EmptyList:

--- a/pkg/lang/seq_test.go
+++ b/pkg/lang/seq_test.go
@@ -1,0 +1,60 @@
+package lang
+
+import (
+	"testing"
+)
+
+func TestCanSeq(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected bool
+	}{
+		// Should return true for seqable types
+		{"nil", nil, true},
+		{"string", "hello", true},
+		{"empty string", "", true},
+		{"slice", []int{1, 2, 3}, true},
+		{"empty slice", []int{}, true},
+		{"array", [3]int{1, 2, 3}, true},
+		{"map", map[string]int{"a": 1}, true},
+		{"empty map", map[string]int{}, true},
+		{"empty list", emptyList, true},
+		{"lazy seq", NewLazySeq(func() interface{} { return nil }), true},
+
+		// Should return false for non-seqable types
+		{"int", 42, false},
+		{"float", 3.14, false},
+		{"bool", true, false},
+		{"struct", struct{ X int }{X: 1}, false},
+		{"pointer to int", new(int), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CanSeq(tt.value)
+			if result != tt.expected {
+				t.Errorf("CanSeq(%v) = %v, expected %v", tt.value, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCanSeqConsistentWithSeq(t *testing.T) {
+	// CanSeq should return true for any value that Seq() doesn't panic on
+	seqableValues := []interface{}{
+		nil,
+		"test",
+		[]int{1, 2, 3},
+		[2]string{"a", "b"},
+		map[string]int{"x": 1},
+		emptyList,
+		NewLazySeq(func() interface{} { return nil }),
+	}
+
+	for _, val := range seqableValues {
+		if !CanSeq(val) {
+			t.Errorf("CanSeq returned false for value that should be seqable: %v", val)
+		}
+	}
+}

--- a/pkg/stdlib/clojure/core/loader.go
+++ b/pkg/stdlib/clojure/core/loader.go
@@ -6492,7 +6492,7 @@ func LoadNS() {
 			checkArity(args, 1)
 			v2 := args[0]
 			_ = v2
-			tmp3 := lang.Apply(nil, []any{v2})
+			tmp3 := lang.CanSeq(v2)
 			return tmp3
 		})
 		tmp1 = tmp1.WithMeta(lang.NewMap(kw_rettag, nil)).(lang.FnFunc)


### PR DESCRIPTION
Add CanSeq() function to pkg/lang/seq.go that checks whether a value can be converted to a sequence. This mirrors the Java implementation of RT.canSeq and returns true for types that implement ISeq, Seqable, as well as strings, slices, arrays, maps, and nil.

Fix seqable? predicate in pkg/stdlib/clojure/core/loader.go to use the new CanSeq function instead of incorrectly calling Apply(nil, ...), which caused "cannot call nil" panics during AOT compilation.

Add comprehensive tests in pkg/lang/seq_test.go covering all seqable and non-seqable types to prevent regression.