### PR TITLE
remove plugin from generated import registry

### DIFF
--- a/cmd/gen-import-interop/main.go
+++ b/cmd/gen-import-interop/main.go
@@ -130,7 +130,6 @@ var defaultPackages = []string{
 	"os/user",
 	"path",
 	"path/filepath",
-	"plugin",
 	"reflect",
 	"regexp",
 	"regexp/syntax",

--- a/pkg/gen/gljimports/gljimports_darwin_amd64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_amd64.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////

--- a/pkg/gen/gljimports/gljimports_darwin_arm64.go
+++ b/pkg/gen/gljimports/gljimports_darwin_arm64.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////

--- a/pkg/gen/gljimports/gljimports_js_wasm.go
+++ b/pkg/gen/gljimports/gljimports_js_wasm.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////

--- a/pkg/gen/gljimports/gljimports_linux_amd64.go
+++ b/pkg/gen/gljimports/gljimports_linux_amd64.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////

--- a/pkg/gen/gljimports/gljimports_linux_arm64.go
+++ b/pkg/gen/gljimports/gljimports_linux_arm64.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////

--- a/pkg/gen/gljimports/gljimports_wasip1_wasm.go
+++ b/pkg/gen/gljimports/gljimports_wasip1_wasm.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////

--- a/pkg/gen/gljimports/gljimports_windows_amd64.go
+++ b/pkg/gen/gljimports/gljimports_windows_amd64.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////

--- a/pkg/gen/gljimports/gljimports_windows_arm.go
+++ b/pkg/gen/gljimports/gljimports_windows_arm.go
@@ -129,7 +129,6 @@ import (
 	os_user "os/user"
 	path "path"
 	path_filepath "path/filepath"
-	plugin "plugin"
 	reflect "reflect"
 	regexp "regexp"
 	regexp_syntax "regexp/syntax"
@@ -6448,13 +6447,6 @@ func RegisterImports(_register func(string, interface{})) {
 	_register("path/filepath.Walk", path_filepath.Walk)
 	_register("path/filepath.WalkDir", path_filepath.WalkDir)
 	_register("path/filepath.WalkFunc", reflect.TypeOf((*path_filepath.WalkFunc)(nil)).Elem())
-
-	// package plugin
-	////////////////////////////////////////
-	_register("plugin.Open", plugin.Open)
-	_register("plugin.Plugin", reflect.TypeOf((*plugin.Plugin)(nil)).Elem())
-	_register("plugin.*Plugin", reflect.TypeOf((*plugin.Plugin)(nil)))
-	_register("plugin.Symbol", reflect.TypeOf((*plugin.Symbol)(nil)).Elem())
 
 	// package reflect
 	////////////////////////////////////////


### PR DESCRIPTION
## Summary
Remove `plugin` from the generated import registry and regenerate the checked-in `pkg/gen/gljimports` files.

## Why
`plugin` is not needed in the default package map, and keeping it in the generated registry forces external linking on `darwin/arm64`.

During investigation for issue #139, that external-link path consistently reproduced a Go linker panic when combined with glojure's large `clojure.core` AOT object. Removing `plugin` at the generator source removes that trigger from all generated targets.

## Impact
Glojure code will no longer resolve `plugin.*` through the default generated package map.

## Validation
- `make glj-imports`
- `rg -n 'plugin\.|"plugin"|plugin/' cmd/gen-import-interop/main.go pkg/gen/gljimports`
- `go build ./cmd/glj`
